### PR TITLE
Don't unescape when splitting.

### DIFF
--- a/lib/edi4r/edifact.rb
+++ b/lib/edi4r/edifact.rb
@@ -104,10 +104,8 @@ module EDI::E
       escapes = count_escapes( item, e )
       if escapes & 1 == 1 # odd
         raise EDISyntaxError, "Pending escape char in #{str}" if match_at == str.length
-        (escapes/2+1).times {item.chop!} # chop off duplicate escapes
         item << s # add separator as regular character
       else # even
-        (escapes/2).times {item.chop!}  # chop off duplicate escapes
         results << item
         item = ''
       end

--- a/test/test_edi_split.rb
+++ b/test/test_edi_split.rb
@@ -20,19 +20,21 @@ include EDI::E
 class TestClass < Test::Unit::TestCase
 
   def test_cde_sep
-    assert_equal(['a','b'], edi_split('a:b', ?:, ??) ) 
-    assert_equal(['a:b'],   edi_split('a?:b', ?:, ??) ) 
-    assert_equal(['a?','b'],edi_split('a??:b', ?:, ??) ) 
-    assert_equal(['a?:b'],  edi_split('a???:b', ?:, ??) ) 
+    assert_equal(['a','b'], edi_split('a:b', ?:, ??) )
+    assert_equal(['a?:b'],   edi_split('a?:b', ?:, ??) )
+    assert_equal(['a??','b'],edi_split('a??:b', ?:, ??) )
+    assert_equal(['a???:b'],  edi_split('a???:b', ?:, ??) )
+    assert_equal(['a????', 'b'],  edi_split('a????:b', ?:, ??) )
+    assert_equal(['a?????:b'],  edi_split('a?????:b', ?:, ??) )
     assert_raise( EDISyntaxError) { edi_split('a:b?', ?:, ??)}
 
-    assert_equal(['a','', 'b'],     edi_split('a::b', ?:, ??) ) 
-    assert_equal(['a','', '', 'b'], edi_split('a:::b', ?:, ??) ) 
-    assert_equal(['a','b'],         edi_split('a:b:', ?:, ??) ) 
-    assert_equal(['a','', 'b'],     edi_split('a::b::', ?:, ??) ) 
+    assert_equal(['a','', 'b'],     edi_split('a::b', ?:, ??) )
+    assert_equal(['a','', '', 'b'], edi_split('a:::b', ?:, ??) )
+    assert_equal(['a','b'],         edi_split('a:b:', ?:, ??) )
+    assert_equal(['a','', 'b'],     edi_split('a::b::', ?:, ??) )
 
-    assert_equal(['','a','b'],            edi_split(':a:b', ?:, ??) ) 
-    assert_equal(['','','', 'a','', 'b'], edi_split(':::a::b::', ?:, ??) ) 
+    assert_equal(['','a','b'],            edi_split(':a:b', ?:, ??) )
+    assert_equal(['','','', 'a','', 'b'], edi_split(':::a::b::', ?:, ??) )
 
     assert_equal( ['123456780', 'A + B LTD' ], edi_split('123456780:A + B LTD', ?:, ??) )
     assert_equal( ['', '', '', '10010099', '25', '131' ], edi_split(':::10010099:25:131', ?:, ??) )
@@ -40,9 +42,9 @@ class TestClass < Test::Unit::TestCase
 
   def test_de_sep
     assert_equal( ['IMD', 'A','', ':::JEANS'], edi_split('IMD+A++:::JEANS', ?+, ??))
-    assert_equal( ['FII', 'OR','123456780:A + B LTD', ':::10010099:25:131' ], edi_split('FII+OR+123456780:A ?+ B LTD+:::10010099:25:131', ?+, ??) )
+    assert_equal( ['FII', 'OR','123456780:A ?+ B LTD', ':::10010099:25:131' ], edi_split('FII+OR+123456780:A ?+ B LTD+:::10010099:25:131', ?+, ??) )
     assert_raise(EDISyntaxError){edi_split('TAG+SOME TEXT??+MORE TEXT+PENDING ESC! ?', ?+, ??)}
-    assert_equal( ['TAG','SOME TEXT?', 'MORE TEXT', 'PENDING ESC ?'], edi_split('TAG+SOME TEXT??+MORE TEXT+PENDING ESC ??', ?+, ??) )
+    assert_equal( ['TAG','SOME TEXT??', 'MORE TEXT', 'PENDING ESC ??'], edi_split('TAG+SOME TEXT??+MORE TEXT+PENDING ESC ??', ?+, ??) )
     assert_raise(EDISyntaxError){edi_split('TAG+SOME TEXT??+MORE TEXT+PENDING ESC! ???', ?+, ??)}
   end
 


### PR DESCRIPTION
The current behavior of `edi_split` is to "remove duplicate escape characters" that appear before the split character.

This causes the following issue:
- A value that ends in a '?' is properly escaped to '??' when it is serialized.
- When parsing the value, we split and take away one of the '?' so we're just left with
'?'.
- This now becomes an invalid value because we have a dangling escape
character at the end of the string.

IMO the correct behavior here should be to ignore the split if the split character is escaped, and not alter the string in any way. I could be missing some other esotaric requirement of the EDI spec though.

# Sentry
https://sentry.io/organizations/flexport/issues/1148030119/events/f1b8c2df158a4deab500269b23d5d0fc/?project=53760

# Fullstory
https://app.fullstory.com/ui/1ILi/session/5982249375891456%3A5087566793474048%3A1565363596898